### PR TITLE
Update processor and register syntax to support Sprockets 2, 3 and 4

### DIFF
--- a/lib/rtlize/railtie.rb
+++ b/lib/rtlize/railtie.rb
@@ -8,7 +8,18 @@ module Rtlize
     config.rtlize.rtl_locales  = Rtlize.rtl_locales
 
     initializer "rtlize.railtie", :after => "sprockets.environment" do |app|
-      app.assets.register_postprocessor 'text/css', Rtlize::RtlProcessor
+      # Support Sprockets 4
+      if app.assets.respond_to?(:register_transformer)
+        app.assets.register_mime_type 'text/css', extensions: ['.css'], charset: :css
+        app.assets.register_postprocessor 'text/css', 'text/css', Rtlize::RtlProcessor
+      end
+
+      # Support Sprockets 2, 3
+      if app.assets.respond_to?(:register_engine)
+        args = ['.css', Rtlize::RtlProcessor]
+        args << { mime_type: 'text/css', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
+        app.assets.register_engine(*args)
+      end
 
       Rtlize.rtl_selector = config.rtlize.rtl_selector
       Rtlize.rtl_locales  = config.rtlize.rtl_locales

--- a/lib/rtlize/rtl_processor.rb
+++ b/lib/rtlize/rtl_processor.rb
@@ -1,17 +1,29 @@
 module Rtlize
   class RtlProcessor
-    attr_reader :data
-
-    def initialize(file, &block)
-      @data = block.call
+    def initialize(filename, &block)
+      @filename = filename
+      @source = block.call
     end
 
     def render(context, locals, &block)
+      self.class.run(@filename, @source, context)
+    end
+
+    def self.run(filename, source, context)
       if context.pathname.basename.to_s.match(/\.rtl\.s?css/i)
-        Rtlize::RTLizer.transform(data)
+        Rtlize::RTLizer.transform(source)
       else
-        data
+        source
       end
+    end
+
+    def self.call(input)
+      filename = input[:filename]
+      source   = input[:data]
+      context  = input[:environment].context_class.new(input)
+
+      result = run(filename, source, context)
+      context.metadata.merge(data: result)
     end
   end
 end


### PR DESCRIPTION
It also has the effect of silencing the deprecation message.

See more:
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#registering-all-versions-of-sprockets-in-processors
